### PR TITLE
Realign aosc-os-abbs bug report template

### DIFF
--- a/views/package.html
+++ b/views/package.html
@@ -31,7 +31,7 @@
 <a href="/revdep/{{ pkg['name']|urlencode }}">Reverse dependency</a>,
 {%- endif %}
 <a href="/qa/packages/{{ pkg['name']|urlencode }}">QA Page</a>,
-<a href="https://github.com/AOSC-Dev/{{ pkg['tree'] }}/issues/new?template=bug-report.md&title={{ pkg['name']|urlencode }}%3A%20">Report issues</a></p>
+<a href="https://github.com/AOSC-Dev/{{ pkg['tree'] }}/issues/new?template=bug-report.yaml&title={{ pkg['name']|urlencode }}%3A%20">Report issues</a></p>
 {% if pkg['srctype'] -%}
 <p><b class="pkg-field" title="auto detected">Upstream</b>:
 {% if 'srcurl_base' in pkg -%}

--- a/views/qa_package.html
+++ b/views/qa_package.html
@@ -31,7 +31,7 @@
 {% if pkg['hasrevdep'] -%}
 <a href="/revdep/{{ pkg['name']|urlencode }}">Reverse dependency</a>,
 {%- endif %}
-<a href="https://github.com/AOSC-Dev/{{ pkg['tree'] }}/issues/new?template=bug-report.md&title={{ pkg['name']|urlencode }}%3A%20">Report issues</a></p>
+<a href="https://github.com/AOSC-Dev/{{ pkg['tree'] }}/issues/new?template=bug-report.yaml&title={{ pkg['name']|urlencode }}%3A%20">Report issues</a></p>
 
 {% if not issues %}
 <p class="tips">No issues. Keep up the good work.</p>


### PR DESCRIPTION
The `bug-report.md` template file was renamed in https://github.com/AOSC-Dev/aosc-os-abbs/commit/a7a936ae2d10cab82ab7b03ebf1562c9911c73c2, causing bug report links to break. This changes the `.md` to `.yaml`.